### PR TITLE
[PAPPY-358] Update oauth url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,13 @@ Two script properties are required in the Google Apps Script project for the con
 Script properties can be saved via the script editor user interface by going to **File > Project 
 properties** and selecting the Script properties tab.
 
+### Data Studio Connector Testing
+
+The steps to test data studio connector after code changes are added in following document.
+
+* https://docs.google.com/document/d/1EqtU7z71B1rO4CI7paX5Drp3XrQI3vCzodwXPRqBogg/edit
+
+
 ### Write Tests
 
 Try to write a test that reproduces the problem you're trying to fix or describes a feature that 

--- a/src/auth.js
+++ b/src/auth.js
@@ -23,7 +23,7 @@ function getOAuthService() {
     return OAuth2.createService('dw')
 
         // Set the endpoint URLs, which are the same for all Google services.
-        .setAuthorizationBaseUrl('https://data.world/oauth/authorize')
+        .setAuthorizationBaseUrl('https://auth.data.world/oauth/authorize')
         .setTokenUrl('https://data.world/oauth/access_token')
 
         // Set the client ID and secret, from the Google Developers Console.


### PR DESCRIPTION
Updated oauth url to use `auth.data.world`

Ticket: https://dataworld.atlassian.net/browse/PAPPY-358

Tested the connector by making changes to app script.

The details of data studio connector testing is added in [this file](https://docs.google.com/document/d/1EqtU7z71B1rO4CI7paX5Drp3XrQI3vCzodwXPRqBogg/edit). 