### PR TITLE
[PAPPY-372] Fix 404 issue while connecting dataset in PI

### DIFF
--- a/src/rest.js
+++ b/src/rest.js
@@ -66,7 +66,7 @@ function sql(datasetKey, sqlQuery, lastRefresh, sampleExtraction) {
     }
 }
 
-var datasetRegex = /^(https?:\/\/data\.world\/)?(.+\/.+)$/;
+var datasetRegex = /^(https?:\/\/[a-z0-9-.]*data\.world\/)?(.+\/.+)$/;
 
 function getSqlEndpoint(dataset) {
     var normalizedDatasetKey = dataset.match(datasetRegex)[2];


### PR DESCRIPTION
Ticket: https://dataworld.atlassian.net/browse/PAPPY-372

- The dataset key was not correct while executing query in PI
- Updated the regex to match the subdomain while connecting to dataset.

**Testing:**
I have tested by connecting to following urls and printed the dataset key and checked.

The following log shows the dataset key for `https://data.world/vinuta-ddw/animal-world`

![image](https://user-images.githubusercontent.com/55782343/193194952-c0ee5872-4c31-44b9-a269-8ff03ec4f57e.png)

The following log show the dataset key for `https://greenfield.app.data.world/jona-fenocchi/test-dataset`

![image](https://user-images.githubusercontent.com/55782343/193195129-8937d6c2-09ab-4261-bd2f-bf664c61377d.png)

