### PR TITLE
Update oauth urls used by google datastudio

### DIFF
--- a/src/appscript.json
+++ b/src/appscript.json
@@ -28,7 +28,6 @@
   },
   "urlFetchWhitelist": [
     "https://api.data.world/v0/",
-    "https://auth.world/oauth",
-    "https://data.world/oauth"
+    "https://auth.world/oauth"
   ]
 }

--- a/src/appscript.json
+++ b/src/appscript.json
@@ -28,6 +28,7 @@
   },
   "urlFetchWhitelist": [
     "https://api.data.world/v0/",
+    "https://auth.world/oauth",
     "https://data.world/oauth"
   ]
 }

--- a/src/auth.js
+++ b/src/auth.js
@@ -24,7 +24,7 @@ function getOAuthService() {
 
         // Set the endpoint URLs, which are the same for all Google services.
         .setAuthorizationBaseUrl('https://auth.data.world/oauth/authorize')
-        .setTokenUrl('https://data.world/oauth/access_token')
+        .setTokenUrl('https://auth.data.world/oauth/access_token')
 
         // Set the client ID and secret, from the Google Developers Console.
         .setClientId(scriptProperties.getProperty('oauthClientId'))


### PR DESCRIPTION
Now that we have an auth domain, we need to add these urls to the allow list.  We should also use this new auth domain for all oauth based logins.