### PR TITLE
[IN-4969] updated to .clasp / added JSON handling for null values

### DIFF
--- a/.clasp.json
+++ b/.clasp.json
@@ -1,0 +1,4 @@
+{
+    "rootDir": "src",
+    "scriptId": "1avSMYrgXdAwp0d4Q5ovp8-Lgruoek6G8d0E2fnuMI0ILHt1oo0IEBUK4"
+  }

--- a/.clasp.json
+++ b/.clasp.json
@@ -1,4 +1,4 @@
 {
     "rootDir": "src",
-    "scriptId": "1avSMYrgXdAwp0d4Q5ovp8-Lgruoek6G8d0E2fnuMI0ILHt1oo0IEBUK4"
+    "scriptId": "1ACxmd5B25KUm74YqyQRzIAJmXUD5W5gk1cVMPbrt9QIArXNnbVJ4teYu"
   }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# data.world — Google Data Studio Community Connector
+# data.world — Google Looker Studio Community Connector
 
-Google Data Studio (beta) turns your data into informative dashboards and reports that are easy to 
+Google Looker Studio (beta) turns your data into informative dashboards and reports that are easy to 
 read, easy to share, and fully customizable. Dashboarding allows you to tell great data stories to 
 support better business decisions.
 
-Create unlimited Data Studio custom reports with full editing and sharing.
+Create unlimited Looker Studio custom reports with full editing and sharing.
 
 data.world’s connector is designed for business intelligence analysts, 
 researchers, journalists, and students who want to include in their reports.
@@ -22,15 +22,15 @@ Create your reports with data from multiple sources, including:
 
 Using the data.world Connector is simple!
 
-1. Visit [Data Studio](https://datastudio.google.com/) and click on **Data Sources** from the left hand navigation.
+1. Visit [Looker Studio](https://lookerstudio.google.com/) and click on **Data Sources** from the left hand navigation.
 1. Click on the + (Add) button in the bottom right corner to create a new Data Source.
 1. Choose community connectors and find `data.world`
 1. Once authorization has successfully completed, configure the parameters and click the **Connect** button in the top right.
-1. Once you successfully connect you can edit/manage fields in the same manner as [any data source](https://support.google.com/datastudio/topic/6268199).
+1. Once you successfully connect you can edit/manage fields in the same manner as [any data source](https://support.google.com/lookerstudio/topic/6268199).
 
-In addition, checkout [this example](https://datastudio.google.com/u/0/reporting/0BzNwSTjlzSe8Umw1bmQ4UGVobVU/page/F3WH)
+In addition, checkout [this example](https://lookerstudio.google.com/u/0/reporting/0BzNwSTjlzSe8Umw1bmQ4UGVobVU/page/F3WH)
 
-[![Police Shootings Report](Police%20Shootings.png)](https://datastudio.google.com/u/0/reporting/0BzNwSTjlzSe8Umw1bmQ4UGVobVU/page/F3WH)
+[![Police Shootings Report](Police%20Shootings.png)](https://lookerstudio.google.com/u/0/reporting/0BzNwSTjlzSe8Umw1bmQ4UGVobVU/page/F3WH)
 
 ## Contributing
 

--- a/gapps.config.json
+++ b/gapps.config.json
@@ -1,4 +1,0 @@
-{
-  "path": "src",
-  "fileId": "1ACxmd5B25KUm74YqyQRzIAJmXUD5W5gk1cVMPbrt9QIArXNnbVJ4teYu"
-}

--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -33,9 +33,5 @@
   "urlFetchWhitelist": [
     "https://api.data.world/v0/",
     "https://data.world/oauth"
-  ],
-  "webapp": {
-    "executeAs": "USER_DEPLOYING",
-    "access": "MYSELF"
-  }
+  ]
 }

--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -11,11 +11,15 @@
   },
   "dataStudio": {
     "addonUrl": "https://data.world/integrations/datastudio2",
-    "authType": ["OAUTH2"],
+    "authType": [
+      "OAUTH2"
+    ],
     "company": "data.world, Inc.",
     "companyUrl": "https://data.world",
     "description": "Create reports with data pulled from one or more data.world datasets using SQL queries.\ndata.world is designed for data and the people who work with data.  From professional projects to open data, data.world helps you host and share your data, collaborate with your team, and capture context and conclusions as you work.",
-    "feeType": ["FREE_TRIAL"],
+    "feeType": [
+      "FREE_TRIAL"
+    ],
     "logoUrl": "https://cdn.filepicker.io/api/file/YB2O14XWSJ2X0AMXHJLf",
     "name": "data.world",
     "privacyPolicyUrl": "https://data.world/privacy/",
@@ -29,5 +33,9 @@
   "urlFetchWhitelist": [
     "https://api.data.world/v0/",
     "https://data.world/oauth"
-  ]
+  ],
+  "webapp": {
+    "executeAs": "USER_DEPLOYING",
+    "access": "MYSELF"
+  }
 }

--- a/src/connector.js
+++ b/src/connector.js
@@ -61,15 +61,15 @@ function getData(request) {
     var datasetKey = request.configParams.dataset;
     var sqlQuery = request.configParams.sqlQuery;
 
-    if (request.scriptParams) {
-        var lastRefresh = request.scriptParams.lastRefresh;
-        var sampleExtraction = request.scriptParams.sampleExtraction;
-    }
+    var lastRefresh = request.scriptParams ? request.scriptParams.lastRefresh : null;
+    var sampleExtraction = request.scriptParams ? request.scriptParams.sampleExtraction : null;
 
+    // Get the list of requested field names
     var requestFields = request.fields.map(function (field) {
         return field.name;
     });
 
+    // Fetch the data and convert it to the data response format
     var dataResponse = toDataResponse(requestFields, sql(
         datasetKey,
         sqlQuery,

--- a/src/mappers.js
+++ b/src/mappers.js
@@ -29,19 +29,30 @@ function toDataResponse(requestFields, rows) {
         filteredFieldNames.push(field.name);
     });
 
+    // Exclude the first row (schema)
     var tableData = rows.slice(1);
     return {
         'schema': filteredTableSchema,
         'rows': tableData.map(function (row) {
             return toRowResponse(filteredFieldNames, row);
+        }).filter(function (row) {
+            // Filter out null rows
+            return row !== null;
         })
     };
 }
 
 function toRowResponse(fieldNames, row) {
+    if (!row) {
+        console.error("Invalid row object:", row);
+        // Skip invalid rows
+        return null; 
+    }
+
     return {
-        'values': fieldNames.map(function (field) {
-            return row[field];
+        'values': fieldNames.map(function(field) {
+            // Check if the row contains the field, if not return null
+            return row.hasOwnProperty(field) ? row[field] : null;
         })
     };
 }
@@ -51,6 +62,8 @@ function toTableSchema(schemaRow) {
 }
 
 function toField(tableSchemaField) {
+    var ftype;
+
     switch (tableSchemaField.type) {
         case 'boolean':
             ftype = 'BOOLEAN';
@@ -67,5 +80,5 @@ function toField(tableSchemaField) {
         'name': tableSchemaField.name,
         'label': tableSchemaField.title ? tableSchemaField.title : tableSchemaField.name,
         'dataType': ftype
-    }
+    };
 }


### PR DESCRIPTION
Ticket: https://dataworld.atlassian.net/browse/IN-4969

## Reported Issue
- Customers are now unable to view their existing reports in Looker from connected data.world sources
- This behavior was confirmed across multiple PIs and MT.

## Hotfix and Updated Implementation
While observing the error in the execution logs of the cloned `master` branch [here](https://script.google.com/home/projects/1ACxmd5B25KUm74YqyQRzIAJmXUD5W5gk1cVMPbrt9QIArXNnbVJ4teYu/edit), I noted an error in parsing JSON that was causing the connection to break.

After adding handlers for `null` values during parsing, you are now able to connect and create dashboards.
Additionally, I have updated the use of `gapps` to `clasp` per: https://developers.google.com/apps-script/guides/clasp

## Testing
Testing was performed on Multi-Tenant using a separate Google Apps Script project following the testing documentation here: https://docs.google.com/document/d/1EqtU7z71B1rO4CI7paX5Drp3XrQI3vCzodwXPRqBogg/edit

Google Apps Script Testing Environment: [looker-studio-connector-testing](https://script.google.com/home/projects/1avSMYrgXdAwp0d4Q5ovp8-Lgruoek6G8d0E2fnuMI0ILHt1oo0IEBUK4/edit)